### PR TITLE
Use Node 24 in publish workflow for npm OIDC support

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           registry-url: "https://registry.npmjs.org"
 
       - name: Enable corepack


### PR DESCRIPTION
npm Trusted Publishing via OIDC requires npm v11+, but Node 22 runners ship with npm 10.x by default, causing `E404 Not Found` on `npm publish`.

Node 24 ships with npm 11+ out of the box, fixing the OIDC token exchange without needing a separate `npm i -g npm@11` step.

Scope: ci
Visibility: internal